### PR TITLE
PMT #114866: Fix make files to pickup correct paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,1 @@
-STAGING_URL=https://mediathreadinfo.stage.ctl.columbia.edu/
-PROD_URL=http://mediathread.info
-STAGING_BUCKET=mediathreadinfo.stage.ctl.columbia.edu
-PROD_BUCKET=mediathreadinfo.info
-
 include *.mk

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,5 @@
+STAGING_URL=https://mediathreadinfo.stage.ctl.columbia.edu/
+PROD_URL=https://mediathread.info
+STAGING_BUCKET ?= mediathreadinfo.stage.ctl.columbia.edu
+PROD_BUCKET ?= mediathread.info
 include *.mk

--- a/hugo.mk
+++ b/hugo.mk
@@ -6,10 +6,10 @@ DRAFT_FLAGS ?= --buildDrafts --verboseLog=true -v
 PROD_FLAGS ?= -s .
 S3_FLAGS ?= --acl-public --delete-removed --no-progress --no-mime-magic --guess-mime-type
 INTERMEDIATE_STEPS ?= echo nothing
-STAGING_BUCKET ?= stage.mediathread.info
+STAGING_URL=https://mediathreadinfo.stage.ctl.columbia.edu/
+PROD_URL=https://mediathread.info
+STAGING_BUCKET ?= mediathreadinfo.stage.ctl.columbia.edu
 PROD_BUCKET ?= mediathread.info
-STAGING_URL ?= stage.mediathread.info
-PROD_URL ?= mediathread.info
 
 runserver:
 	$(HUGO) $(DRAFT_FLAGS) \

--- a/hugo.mk
+++ b/hugo.mk
@@ -6,10 +6,6 @@ DRAFT_FLAGS ?= --buildDrafts --verboseLog=true -v
 PROD_FLAGS ?= -s .
 S3_FLAGS ?= --acl-public --delete-removed --no-progress --no-mime-magic --guess-mime-type
 INTERMEDIATE_STEPS ?= echo nothing
-STAGING_URL=https://mediathreadinfo.stage.ctl.columbia.edu/
-PROD_URL=https://mediathread.info
-STAGING_BUCKET ?= mediathreadinfo.stage.ctl.columbia.edu
-PROD_BUCKET ?= mediathread.info
 
 runserver:
 	$(HUGO) $(DRAFT_FLAGS) \


### PR DESCRIPTION
This commit moves the stage and prod urls and bucket names to `hugo.mk`.
In initailly setting up the deployment I didn't see the parent urls -
which aparently I had set up years ago and totally forgot. This moves it
to `hugo.mk` so its easier to see.